### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ tmp*
 test_*
 .vscode
 ec2_*
+
+
+# Files related to tools directory
+clouds.yaml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     - [Completion](#completion)
 - [Task runner](#task-runner)
   - [command list](#command-list)
+  - [Logging](#logging)
 - [Details](#details)
 - [Troubleshooting](#troubleshooting)
   - [Setup fails due to rate limit for github REST API](#setup-fails-due-to-rate-limit-for-github-rest-api)
@@ -365,6 +366,15 @@ Recreate cluster (run `task cleanup` and `task cluster`)
 task recreate
 ```
 
+## Logging
+
+By default, the output from the playbook is displayed in stdout and stderr.
+You can use the command "set logfile=[filename]" on running tasks to log the outputs.
+For example, the command below will run setup.yml and record the playbooks result in the `ansible.log`.
+
+```
+task logfile=ansible.log
+```
 
 
 # Details

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   - [Tools](#tools)
     - [Alias](#alias)
     - [Completion](#completion)
+- [Task runner](#task-runner)
+  - [command list](#command-list)
 - [Details](#details)
 - [Troubleshooting](#troubleshooting)
   - [Setup fails due to rate limit for github REST API](#setup-fails-due-to-rate-limit-for-github-rest-api)
@@ -129,26 +131,26 @@ $ ansible-playbook setup.yml
 The setup playbook installs the necessary CLI, creates the cluster, and deploys the following components. You can manage whether each component is installed during the installation process by editing the inventory file. See [setup_cluster.md](docs/setup_cluster.md) for details.
 
 
-| Component | Category | Installed by default |
-| - | - | - |
-| Nginx ingress controller | Ingress controller | yes |
-| Traefik | Ingress controller and proxy | no |
-| OpenEBS | Storage | no |
-| Longhorn | Storage | no |
-| Kubevious | Dashboard | no |
-| Octant | Dashboard | no |
-| Tekton | CI/CD platform | no |
-| Argocd | CD tool | no |
-| Harbor | Image registry | no |
-| Gitea | Git server | no |
-| Kube-prometheus-stack | Monitoring | no |
-| Openfaas | Serverless framework | no |
-| Cert manager | Certificates management | no |
-| Jaeger | Distributed tracing system | no |
-| Linkerd | Service mesh | no |
-| Velero | Backup and restore management | no |
-| Awx | Web-based platform for Ansible | no |
-| Stackstorm | Platform for integration and automation | no |
+| Component                | Category                                | Installed by default |
+| ------------------------ | --------------------------------------- | -------------------- |
+| Nginx ingress controller | Ingress controller                      | yes                  |
+| Traefik                  | Ingress controller and proxy            | no                   |
+| OpenEBS                  | Storage                                 | no                   |
+| Longhorn                 | Storage                                 | no                   |
+| Kubevious                | Dashboard                               | no                   |
+| Octant                   | Dashboard                               | no                   |
+| Tekton                   | CI/CD platform                          | no                   |
+| Argocd                   | CD tool                                 | no                   |
+| Harbor                   | Image registry                          | no                   |
+| Gitea                    | Git server                              | no                   |
+| Kube-prometheus-stack    | Monitoring                              | no                   |
+| Openfaas                 | Serverless framework                    | no                   |
+| Cert manager             | Certificates management                 | no                   |
+| Jaeger                   | Distributed tracing system              | no                   |
+| Linkerd                  | Service mesh                            | no                   |
+| Velero                   | Backup and restore management           | no                   |
+| Awx                      | Web-based platform for Ansible          | no                   |
+| Stackstorm               | Platform for integration and automation | no                   |
 
 # Configuration
 
@@ -318,6 +320,51 @@ fpath=($ZSH/custom/completions $fpath)
 autoload -U compinit && compinit
 # -- END inserted by kubectx ansible task --
 ```
+
+
+# Task runner
+
+[Task runner](https://github.com/go-task/task) is supported for running commands more easier. Make sure that [task install](https://taskfile.dev/installation/) to use the feature.
+
+
+## command list
+
+Run setup (equivalent to  `ansible-playbook setup.yml`)
+
+```
+task
+```
+
+Run the specific role or task with tags (equivalent to  `ansible-playbook setup.yml -t [tags]`)
+
+```
+task tags -- [tags]
+```
+
+When specifying more than one tag, separate them with comma.
+
+```
+task tags -- tag1,tag2,tag3
+```
+
+
+Cleanup the current cluster (equivalent to  `ansible-playbook playbook/cleanup_cluster.yml`)
+
+```
+task cleanup
+```
+
+Create cluster (just create cluster by kubeadm and install ingress controller, not install additional component.)
+```
+task cluster
+```
+
+Recreate cluster (run `task cleanup` and `task cluster`)
+
+```
+task recreate
+```
+
 
 
 # Details

--- a/README.md
+++ b/README.md
@@ -389,5 +389,12 @@ To avoid this issue, set `github_api_token_enabled: true` and value of the githu
 
 The playbooks are tested against on the following distributions.
 
-- Rockylinux 9.2
-- Ubuntu 23.04
+- Ubuntu
+    - 23.04
+    - 24.04
+    - 24.10
+    - 25.04
+- Rockylinux
+    - 9.2
+    - 9.4
+    - 9.5

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,22 @@
+version: "3"
+
+env:
+  inventory: inventory.yml
+
+tasks:
+  default:
+    cmds:
+      - ansible-playbook -i ${inventory} setup.yml
+  tags:
+    cmds:
+      - ansible-playbook -i ${inventory} setup.yml -t {{ .CLI_ARGS }}
+  cluster:
+    cmds:
+      - ansible-playbook -i ${inventory} setup.yml -t cluster,coredns,add_worker,ingress,kube_ps1
+  clean:
+    cmds:
+      - ansible-playbook -i ${inventory} playbooks/cleanup_cluster.yml
+  recreate:
+    cmds:
+      - task: clean
+      - task: cluster

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,10 @@
 version: "3"
 
 env:
-  inventory: inventory.yml
+  # inventory: inventory.yml
+  inventory: tmp_inventory_ha.yml
+  logfile: '{{ .logfile | default "" }}'
+  ANSIBLE_LOG_PATH: ${logfile}
 
 tasks:
   default:

--- a/inventory.yml
+++ b/inventory.yml
@@ -36,6 +36,7 @@ all:
       enabled: false
     github_api_token_enabled: false
     github_api_token: ""
+    coredns_updated: false
   children:
     cluster:
       vars:

--- a/inventory_ha.yml
+++ b/inventory_ha.yml
@@ -36,6 +36,7 @@ all:
       enabled: false
     github_api_token_enabled: false
     github_api_token: ""
+    coredns_updated: false
   children:
     cluster:
       vars:

--- a/playbooks/setup_cluster.yml
+++ b/playbooks/setup_cluster.yml
@@ -24,10 +24,6 @@
         name: kubeadm
         tasks_from: put_admin_conf
 
-    - name: Install CNI
-      ansible.builtin.include_role:
-        name: "{{ cni_type }}"
-
     - name: Taint control plane nodes
       ansible.builtin.command: |
         kubectl taint nodes --all node-role.kubernetes.io/control-plane-

--- a/playbooks/setup_cni.yml
+++ b/playbooks/setup_cni.yml
@@ -1,0 +1,8 @@
+---
+- name: Install CNI
+  hosts: control_plane[0]
+  gather_facts: false
+  tasks:
+    - name: Install CNI
+      ansible.builtin.include_role:
+        name: "{{ cni_type }}"

--- a/playbooks/setup_coredns.yml
+++ b/playbooks/setup_coredns.yml
@@ -1,0 +1,8 @@
+---
+- hosts: control_plane[0]
+  gather_facts: false
+  tasks:
+    - name: Update CoreDNS configuration
+      ansible.builtin.import_role:
+        name: coredns
+        tasks_from: update_configmap.yml

--- a/roles/coredns/defaults/main.yml
+++ b/roles/coredns/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# List of extra host added to CoreDNS configmaps.
+# Set hostname and IP address.
+coredns_extra_hosts: []
+# coredns_extra_hosts:
+#   - mytestdomain.com: 192.168.3.1
+
+# List of DNS server added to CoreDNS configmaps.
+coredns_additional_dns: []
+# coredns_additional_dns:
+#   - 192.168.3.2
+#   - 8.8.8.8
+
+# List of stub domain and upstream server.
+# See https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configuration-of-stub-domain-and-upstream-nameserver-using-coredns
+coredns_additional_data: []
+# coredns_additional_data:
+#   - name: consul
+#     value: |
+#       consul.local:53 {
+#         errors
+#         cache 30
+#         forward . 10.150.0.1
+#       }

--- a/roles/coredns/tasks/update_configmap.yml
+++ b/roles/coredns/tasks/update_configmap.yml
@@ -1,0 +1,19 @@
+---
+- name: Put configmap manifest
+  ansible.builtin.template:
+    src: configmap.yml.j2
+    dest: /tmp/coredns_configmap.yml
+
+- name: Apply configmap manifest
+  kubernetes.core.k8s:
+    state: patched
+    src: /tmp/coredns_configmap.yml
+
+- name: Rollout coredns pods
+  ansible.builtin.command: kubectl rollout restart deployment -n kube-system coredns
+  register: result
+  until: result.rc == 0
+  retries: 5
+  delay: 10
+  failed_when: result.rc != 0
+  changed_when: result.rc == 0

--- a/roles/coredns/templates/configmap.yml.j2
+++ b/roles/coredns/templates/configmap.yml.j2
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+           lameduck 5s
+        }
+        {% if coredns_extra_hosts | length > 0 -%}
+        hosts {
+          {% for host in coredns_extra_hosts -%}
+          {% for hostname, ip in host.items() -%}
+          {{ hostname }} {{ ip }}
+          {% endfor -%}
+          {% endfor -%}
+          fallthrough
+        }
+        {% endif -%}
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+           pods insecure
+           fallthrough in-addr.arpa ip6.arpa
+           ttl 30
+        }
+        prometheus :9153
+        {% if coredns_additional_dns | length > 0 -%}
+        {% for dns_server in coredns_additional_dns -%}
+        forward . {{ dns_server }} {
+           max_concurrent 1000
+        }
+        {% endfor -%}
+        {% endif -%}
+        forward . /etc/resolv.conf {
+           max_concurrent 1000
+        }
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+    {% if coredns_additional_data | length > 0 -%}
+    {% for data in coredns_additional_data -%}
+    {{ data.value | indent(4) }}
+    {% endfor %}
+    {% endif %}

--- a/roles/flannel/defaults/main.yml
+++ b/roles/flannel/defaults/main.yml
@@ -1,2 +1,10 @@
 ---
+# manifest or helm
+flannel_install_mode: helm
+
 flannel_manifest_url: https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml
+
+# Helm
+flannel_namespace: kube-flannel
+flannel_release_name: flannel
+pod_network_cidr: "10.244.0.0/16"

--- a/roles/flannel/tasks/install.yml
+++ b/roles/flannel/tasks/install.yml
@@ -1,0 +1,55 @@
+---
+- name: Install flannel with manifest
+  when: flannel_install_mode == "manifest"
+  block:
+    - name: Download flannel manifest
+      ansible.builtin.get_url:
+        url: "{{ flannel_manifest_url }}"
+        dest: /tmp/kube-flannel.yml
+        mode: "0644"
+
+    - name: Deploy flannel
+      kubernetes.core.k8s:
+        state: present
+        src: /tmp/kube-flannel.yml
+
+- name: Install flannel with helm
+  when: flannel_install_mode == "helm"
+  block:
+    - name: "Create {{ flannel_namespace }} namespace"
+      kubernetes.core.k8s:
+        name: "{{ flannel_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: present
+
+    - name: add label to existing namespace
+      kubernetes.core.k8s:
+        state: patched
+        kind: Namespace
+        name: "{{ flannel_namespace }}"
+        definition:
+          metadata:
+            labels:
+              pod-security.kubernetes.io/enforce: privileged
+
+    - name: Add flannel repository
+      kubernetes.core.helm_repository:
+        name: flannel
+        repo_url: https://flannel-io.github.io/flannel/
+
+    - name: Separately update the repository cache
+      kubernetes.core.helm:
+        name: dummy
+        namespace: kube-system
+        state: absent
+        update_repo_cache: true
+
+    - name: Helm install flannel
+      kubernetes.core.helm:
+        name: "{{ flannel_release_name }}"
+        chart_ref: flannel/flannel
+        release_namespace: "{{ flannel_namespace }}"
+        set_values:
+          - value: "podCidr={{ pod_network_cidr }}"
+            value_type: string

--- a/roles/flannel/tasks/main.yml
+++ b/roles/flannel/tasks/main.yml
@@ -1,11 +1,2 @@
 ---
-- name: Download flannel manifest
-  ansible.builtin.get_url:
-    url: "{{ flannel_manifest_url }}"
-    dest: /tmp/kube-flannel.yml
-    mode: "0644"
-
-- name: Deploy flannel
-  kubernetes.core.k8s:
-    state: present
-    src: /tmp/kube-flannel.yml
+- ansible.builtin.import_tasks: install.yml

--- a/roles/kubecolor/tasks/install.yml
+++ b/roles/kubecolor/tasks/install.yml
@@ -6,7 +6,7 @@
   vars:
     organization: kubecolor
     repository: kubecolor
-    query_string: "linux_{{ arch }}"
+    query_string: "linux_{{ arch }}.tar.gz"
 
 - name: Download kubecolor
   ansible.builtin.get_url:

--- a/roles/kubernetes/tasks/install.yml
+++ b/roles/kubernetes/tasks/install.yml
@@ -7,6 +7,16 @@
         url: "https://api.github.com/repos/kubernetes/kubernetes/releases/latest"
         return_content: true
       register: query_result
+      when: not github_api_token_enabled | bool
+
+    - name: Get the latest release from github with PAT
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/kubernetes/kubernetes/releases/latest"
+        return_content: true
+        headers:
+          Authorization: "Bearer {{ github_api_token }}"
+      register: query_result
+      when: github_api_token_enabled | bool
 
     - name: Fix format to json
       ansible.builtin.set_fact:
@@ -158,4 +168,4 @@
     - name: "Add kubectl completion in {{ node_shell }}rc"
       ansible.builtin.lineinfile:
         path: "/home/{{ node_user }}/.{{ node_shell }}rc"
-        line: 'source <(kubectl completion {{ node_shell }})'
+        line: "source <(kubectl completion {{ node_shell }})"

--- a/roles/popeye/tasks/install.yml
+++ b/roles/popeye/tasks/install.yml
@@ -6,7 +6,7 @@
   vars:
     organization: derailed
     repository: popeye
-    query_string: "linux_{{ arch }}"
+    query_string: "linux_{{ arch }}.tar.gz"
 
 - name: Download popeye
   ansible.builtin.get_url:
@@ -15,17 +15,32 @@
     mode: "0644"
   become: true
 
+- name: mkdir popeye
+  ansible.builtin.file:
+    path: "/tmp/popeye"
+    state: directory
+  become: true
+
 - name: Extract
   ansible.builtin.unarchive:
     src: "/tmp/popeye_{{ arch }}.tar.gz"
-    dest: "/tmp"
+    dest: "/tmp/popeye"
     remote_src: true
   become: true
 
 - name: Put binary in /usr/local/bin
   ansible.builtin.copy:
-    src: "/tmp/popeye"
+    src: "/tmp/popeye/popeye"
     dest: "/usr/local/bin"
     remote_src: true
     mode: "0755"
   become: true
+
+- name: Cleanup
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  become: true
+  loop:
+    - /tmp/popeye
+    - "/tmp/popeye_{{ arch }}.tar.gz"

--- a/setup.yml
+++ b/setup.yml
@@ -29,6 +29,10 @@
     - coredns_updated is defined
     - coredns_updated | bool
 
+- name: Setup CNI
+  ansible.builtin.import_playbook: playbooks/setup_cni.yml
+  tags: cni
+
 - name: Add worker nodes
   ansible.builtin.import_playbook: playbooks/add_worker.yml
   tags: add_worker

--- a/setup.yml
+++ b/setup.yml
@@ -22,6 +22,13 @@
   tags: cluster
   when: ha_cluster.enabled | bool
 
+- name: Update CoreDNS configuration
+  ansible.builtin.import_playbook: playbooks/setup_coredns.yml
+  tags: coredns
+  when:
+    - coredns_updated is defined
+    - coredns_updated | bool
+
 - name: Add worker nodes
   ansible.builtin.import_playbook: playbooks/add_worker.yml
   tags: add_worker

--- a/tools/vm_images/README.md
+++ b/tools/vm_images/README.md
@@ -1,0 +1,212 @@
+
+
+
+- [VM images](#vm-images)
+- [Prerequisites](#prerequisites)
+  - [Openstack](#openstack)
+    - [cloud.yaml](#cloudyaml)
+    - [vars.yml](#varsyml)
+- [Usage](#usage)
+  - [Examples](#examples)
+    - [Openstack](#openstack-1)
+- [Create k8s cluster on VM created from the images](#create-k8s-cluster-on-vm-created-from-the-images)
+
+
+# VM images
+
+Since it takes a little time to install the packages required for k8s cluster, it is more effective to create a VM image containing the required packages (so-called Golden image) in order to reduce time spent to provisioning.
+These playbooks are tools to create images or snapshots from the existing VM that have completed setup for k8s but yet created a cluster, and to quickly create cluster the next time.
+
+# Prerequisites
+
+The prerequisites for using this depends on which provider to use in order to create images. Support providers are the following.
+
+- openstack
+
+
+## Openstack
+
+The openstack provider is used when the user uses the VMs on openstack. Create images from VMs on openstack as snapshot and store them on openstack image store (glance).
+The following packages are required.
+
+- openstack CLI
+
+Install with pip.
+```
+pip install python-openstackclient
+```
+
+- [Ansible OpenStack Collection](https://galaxy.ansible.com/ui/repo/published/openstack/cloud/)
+
+Install with ansible galaxy.
+```
+ansible-galaxy collection install openstack.cloud
+```
+
+
+### cloud.yaml
+
+clouds.yaml is a configuration file that contains everything needed to connect to openstack cloud (see [openstack page](https://docs.openstack.org/python-openstackclient/pike/configuration/index.html) for details).
+Cloud.yaml is required on the node executing the playbook to connect the Openstack server.
+Cloud name is arbitrary but `auth` and the following fields are required.
+
+```yml
+clouds:
+  kolla-admin:
+    auth:
+      auth_url: http://192.168.3.2:5000
+      project_domain_name: Default
+      user_domain_name: Default
+      project_name: admin
+      username: admin
+      password: xxxyyyzz
+```
+
+### vars.yml
+
+Define to create image from which server and other properties in `vars.yml`. The following field are needed.
+
+- provider: Set `openstack`.
+- openstack_cloud: Must match the cloud name in `clouds.yaml`.
+- servers (list): Define server and image.
+
+Supported field in servers are the following.
+
+| Field       | Description                                                                                                           | Required |
+| ----------- | --------------------------------------------------------------------------------------------------------------------- | -------- |
+| server_name | Name of openstack server                                                                                              | yes      |
+| image_name  | Name of image create by the server above.<br> The image name must not be the same as the existing image on openstack. | yes      |
+| properties  | Properties added to the image. Set key-value pairs.                                                                   | no       |
+
+
+Examples
+
+```yml
+provider: openstack
+openstack_cloud: kolla-admin
+servers:
+  - server_name: k8s-m1
+    image_name: k8s-master_ubuntu-23.04_20240721
+  - server_name: k8s-w1
+    image_name: k8s-worker_ubuntu-23.04_20240721
+    properties:
+      os_type: linux
+      os_distro: ubuntu
+      os_version: "23.04"
+      os_admin_user: debian
+```
+
+
+# Usage
+
+To create image users need to install packages for k8s cluster. Create a VM as usual and set the host information in `inventory.yml` and put it in project root directory.
+
+```yml
+...
+    control_plane:
+      hosts:
+        k8s-m1:
+          ansible_host: 192.168.3.2
+    worker:
+      hosts:
+        k8s-w1:
+          ansible_host: 192.168.3.3
+```
+
+Set which VM to create the image from, the image name and other properties in `vars.yml` and put it in the current directory.
+A configuration file for each provider is also required.
+
+Then run `create_image.sh`. This script runs the following steps.
+
+1. Install packages required for k8s cluster on VMs.
+2. Stop VMs.
+3. Create images or snapshots from the VMs and upload them to image store in cloud provider you selected.
+
+
+
+## Examples
+
+### Openstack
+
+Set host information such as IP Address, user and etc. in `inventory.yml` of project root directory.
+
+```yml
+    control_plane:
+      hosts:
+        k8s-m1:
+          ansible_host: 192.168.3.2
+    worker:
+      hosts:
+        k8s-w1:
+          ansible_host: 192.168.3.3
+```
+
+Prepare `clouds.yaml` to connect to the openstack.
+```yml
+clouds:
+  kolla-admin:
+    auth:
+      auth_url: http://192.168.3.2:5000
+      project_domain_name: Default
+      user_domain_name: Default
+      project_name: admin
+      username: admin
+      password: xxxyyyzz
+```
+
+Set server and image name in `vars.yml`.
+```yml
+provider: openstack
+openstack_cloud: kolla-admin
+servers:
+  - server_name: k8s-m1
+    image_name: k8s-master_ubuntu-23.04_20240721
+  - server_name: k8s-w1
+    image_name: k8s-worker_ubuntu-23.04_20240721
+    properties:
+      os_type: linux
+      os_distro: ubuntu
+      os_version: "23.04"
+      os_admin_user: debian
+```
+
+Run `create_image.sh`.
+```
+./create_image.sh
+```
+
+When all tasks successfully finished the image would be created from each server and uploaded to the openstack.
+```
+$ openstack image list
++--------------------------------------+----------------------------------+--------+
+| ID                                   | Name                             | Status |
++--------------------------------------+----------------------------------+--------+
+| 6bd3c9b2-810e-4af0-9c33-fb57cf18fa6d | k8s-master_ubuntu-23.04_20240721 | active |
+| 8058dce8-bb1d-4275-adda-7955a2f0d2df | k8s-worker_ubuntu-23.04_20240721 | active |
+|--------------------------------------+----------------------------------+--------+
+```
+
+
+
+The status of servers would be `SHUTOFF` since the snapshot can be created only when server is stopped.
+```
+$ openstack server list -c ID -c Name -c Status
++--------------------------------------+------------+---------+
+| ID                                   | Name       | Status  |
++--------------------------------------+------------+---------+
+| 403d1e8b-d9f6-435d-9d65-ae7865b8fb91 | k8s-m1     | SHUTOFF |
+| 3152301c-43ff-48da-935a-b7606dd3aade | k8s-w1     | SHUTOFF |
++--------------------------------------+------------+---------+
+```
+
+
+
+# Create k8s cluster on VM created from the images
+
+VMs created from the image above contains all required packages for k8s cluster, so no need to run tasks to install the packages. To create k8s cluster just run the following steps.
+
+1. Create VMs from the images.
+2. Run `setup.yml` with `--skip-tags module,components,k8s_plugins`.
+```
+ansible-playbook setup.yml --skip-tags module,components,k8s_plugins
+```

--- a/tools/vm_images/ansible.cfg
+++ b/tools/vm_images/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+inventory = inventory.yml
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+host_key_checking = False
+interpreter_python = /usr/bin/python3
+roles_path = ./roles:../../roles
+display_skipped_hosts = no
+callbacks_enabled = ansible.posix.timer, ansible.posix.profile_tasks

--- a/tools/vm_images/create_image.sh
+++ b/tools/vm_images/create_image.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ue
+
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+
+# Setup VMs
+cd ../../
+ansible-playbook setup.yml \
+    -t module \
+    -t components \
+    -t k8s_plugins
+
+# Create imggaes from VMs
+cd ${CURRENT_DIR}
+ansible-playbook create_image.yml

--- a/tools/vm_images/create_image.yml
+++ b/tools/vm_images/create_image.yml
@@ -1,0 +1,30 @@
+- name: Create VM images
+  hosts: localhost
+  connection: localhost
+  vars_files:
+    - vars.yml
+  tags: vm_image
+  tasks:
+    - name: Openstack
+      when: provider == "openstack"
+      block:
+        - name: Include clouds.yaml
+          ansible.builtin.include_vars:
+            file: clouds.yaml
+
+        - name: Set openstack environment variables
+          set_fact:
+            openstack_env:
+              OS_AUTH_URL: "{{ cloud.auth.auth_url }}"
+              OS_PROJECT_DOMAIN_NAME: "{{ cloud.auth.project_domain_name | default('Default') }}"
+              OS_USER_DOMAIN_NAME: "{{ cloud.auth.user_domain_name | default('Default') }}"
+              OS_PROJECT_NAME: "{{ cloud.auth.project_name | default('admin') }}"
+              OS_USERNAME: "{{ cloud.auth.username | default('admin') }}"
+              OS_PASSWORD: "{{ cloud.auth.password }}"
+          vars:
+            cloud: "{{ clouds[openstack_cloud] }}"
+
+        - name: Create snapshot for each server
+          ansible.builtin.include_tasks: playbooks/openstack_make_snapshot.yml
+          loop: "{{ servers }}"
+

--- a/tools/vm_images/examples/openstack_clouds.yml
+++ b/tools/vm_images/examples/openstack_clouds.yml
@@ -1,0 +1,9 @@
+clouds:
+  kolla-admin:
+    auth:
+      auth_url: http://192.168.3.2:5000
+      project_domain_name: Default
+      user_domain_name: Default
+      project_name: admin
+      username: admin
+      password: xxxyyyzz

--- a/tools/vm_images/examples/openstack_vars.yml
+++ b/tools/vm_images/examples/openstack_vars.yml
@@ -1,0 +1,13 @@
+---
+provider: openstack
+openstack_cloud: kolla-admin
+servers:
+  - server_name: k8s-m1
+    image_name: k8s-master_ubuntu-23.03_20240721
+  - server_name: k8s-w1
+    image_name: k8s-worker_ubuntu-23.03_20240721
+    properties:
+      os_type: linux
+      os_distro: ubuntu
+      os_version: "23.03"
+      os_admin_user: ubuntu

--- a/tools/vm_images/playbooks/openstack_make_snapshot.yml
+++ b/tools/vm_images/playbooks/openstack_make_snapshot.yml
@@ -1,0 +1,21 @@
+---
+- name: Stop VM
+  ansible.builtin.import_role:
+    name: openstack
+    tasks_from: stop_vm.yml
+  vars:
+    openstack: "{{ openstack_cloud }}"
+    server_name: "{{ item.server_name }}"
+    image_name: "{{ item.image_name }}"
+  environment: "{{ openstack_env }}"
+
+- name: Create snapshot from VM
+  ansible.builtin.import_role:
+    name: openstack
+    tasks_from: create_image.yml
+  vars:
+    openstack: "{{ openstack_cloud }}"
+    server_name: "{{ item.server_name }}"
+    image_name: "{{ item.image_name }}"
+    properties: "{{ item.properties }}"
+  environment: "{{ openstack_env }}"

--- a/tools/vm_images/roles/openstack/defaults/main.yml
+++ b/tools/vm_images/roles/openstack/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+openstack_cloud: "kolla-admin"
+openstack_timeout: 600

--- a/tools/vm_images/roles/openstack/tasks/create_image.yml
+++ b/tools/vm_images/roles/openstack/tasks/create_image.yml
@@ -1,0 +1,24 @@
+---
+- name: Check if the image exists
+  openstack.cloud.image_info:
+    cloud: "{{ openstack_cloud }}"
+    name: "{{ image_name }}"
+  register: image_info
+
+- name: "Create image '{{ image_name }}' from {{ server_name }}"
+  ansible.builtin.command: >
+      openstack server image create
+      --name {{ image_name }}
+      --wait
+      --os-cloud {{ openstack_cloud }}
+      {{ server_name }}
+  register: result
+  changed_when: result.rc == 0
+  failed_when: result.rc != 0
+  when: image_info.images | length == 0
+
+- name: Update image properties
+  ansible.builtin.import_tasks: update_image.yml
+  when:
+    - properties is defined and properties | length > 0
+    - result.rc is defined and result.rc == 0

--- a/tools/vm_images/roles/openstack/tasks/stop_vm.yml
+++ b/tools/vm_images/roles/openstack/tasks/stop_vm.yml
@@ -1,0 +1,7 @@
+---
+- name: "Stop server: {{ server_name }}"
+  openstack.cloud.server_action:
+    cloud: "{{ openstack_cloud }}"
+    action: stop
+    server: "{{ server_name }}"
+    timeout: "{{ openstack_timeout }}"

--- a/tools/vm_images/roles/openstack/tasks/update_image.yml
+++ b/tools/vm_images/roles/openstack/tasks/update_image.yml
@@ -1,0 +1,19 @@
+---
+- name: Fetch current properties
+  openstack.cloud.image_info:
+    cloud: "{{ openstack_cloud }}"
+    name: "{{ image_name }}"
+  register: image_info
+
+- name: Merge properties
+  ansible.builtin.set_fact:
+    _properties: "{{ image_info.images[0].properties | combine(properties) }}"
+
+- name: "Update {{ image_name }} properties"
+  openstack.cloud.image:
+    cloud: "{{ openstack_cloud }}"
+    name: "{{ image_name }}"
+    container_format: bare
+    disk_format: qcow2
+    state: present
+    properties: "{{ _properties }}"


### PR DESCRIPTION
### Summary of Changes by copilot

- Fixed kubecolor Installation Task: https://github.com/git-ogawa/setup_kube_cluster/pull/16/commits/9926563f3c81502d54471d1f9d601955a95b2770
    - Explicitly downloads .tar.gz archives to prevent unintended package downloads.
- Added CoreDNS Configuration Update Feature: https://github.com/git-ogawa/setup_kube_cluster/pull/16/commits/c647d37f2298ceda721237a2a369ebed80b9cead
    - Introduced new tasks and templates for updating CoreDNS configurations.
    - Controlled by the coredns_updated flag.
- Improve CNI Installation: https://github.com/git-ogawa/setup_kube_cluster/pull/16/commits/0556790ad8c3f54065e37ca0b9ebef258190aecf
    - Moved CNI (e.g., Flannel) installation tasks to setup_cni.yml.
    - Added support for Flannel installation via manifest or helm.
- Support for Newer OS Versions: https://github.com/git-ogawa/setup_kube_cluster/pull/16/commits/05bf5f96718e4a7ffd656a39be8edd8eb9f2a1b4
    - Added some cloud images including Ubuntu 25.04 and Rocky Linux 9.5.
- Introduced task runner: https://github.com/git-ogawa/setup_kube_cluster/pull/16/commits/b9b81a7a1fca2f1fb96f0c1bea5332fe43d14c4d
    - Added Taskfile.yml to simplify running Ansible playbooks.
    - Tasks include cluster creation, cleanup, and recreation.
- Introduced Task Runner Logging: https://github.com/git-ogawa/setup_kube_cluster/pull/16/commits/58d858bf18d50ef76aede9980e1f14f8bff671fd
    - Added logging feature to the task runner, allowing users to specify a log file for playbook outputs.
- Added OpenStack Image Creation Tools: https://github.com/git-ogawa/setup_kube_cluster/pull/16/commits/cb1a08d2c9e491c3047e1f549b17cc604868e5e2
    - Introduced tools for creating VM images in OpenStack environments.
    - Enables the creation of golden images with pre-installed packages.
